### PR TITLE
Created FFI for MnemonicWallet

### DIFF
--- a/.github/workflows/wallet.yml
+++ b/.github/workflows/wallet.yml
@@ -48,4 +48,4 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy -- -D warnings
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --all-features

--- a/packages/crw-wallet/Cargo.toml
+++ b/packages/crw-wallet/Cargo.toml
@@ -24,6 +24,8 @@ thiserror = "1.0.24"
 wasm-bindgen-futures = { version = "0.4.21", optional = true}
 parking_lot = { version = "0.11.1", default-features = false, features = ["wasm-bindgen"], optional = true }
 rand = { version = "0.7.3", features = ["wasm-bindgen"], optional = true }
+libc = { version = "0.2.94", optional = true }
+ffi_helpers = { version = "0.2.0", optional = true }
 
 [dependencies.bindgen]
 version = "0.2.70"
@@ -38,3 +40,4 @@ hex = "0.4.3"
 [features]
 default = []
 wasm-bindgen = ["bindgen", "wasm-bindgen-futures", "parking_lot", "rand"]
+ffi = ["libc", "ffi_helpers"]

--- a/packages/crw-wallet/ffi-binding.h
+++ b/packages/crw-wallet/ffi-binding.h
@@ -68,6 +68,17 @@ void wallet_free(wallet_t* wallet);
 char* wallet_get_bech32_address(wallet_t *wallet, const char* hrp);
 
 /**
+ * @brief GGets secp256 public key from the wallet.
+ * @param wallet: Pointer to the wallet instance.
+ * @param out_buffer: Pointer where will be stored the public key
+ * @param size: Size of out_buffer.
+ * @return Returns the number of bytes wrote inside out_buffer on success,
+ * -1 if the provided arguments are invalid or -2 if the public key don't fit
+ * into out_buffer.
+ */
+int wallet_get_public_key(wallet_t *wallet, uint8_t *out_buffer, int size);
+
+/**
  * @brief Performs the signature of the provided data.
  * @param wallet: Pointer to the wallet instance.
  * @param data: The data to sign.

--- a/packages/crw-wallet/ffi-binding.h
+++ b/packages/crw-wallet/ffi-binding.h
@@ -1,0 +1,105 @@
+/***
+ * @brief This C header file expose the function defined inside the ffi crate.
+ */
+
+#include <stdint.h>
+
+typedef struct wallet wallet_t;
+
+/**
+ * @brief Struct that represent a signature.
+ */
+typedef struct {
+  /**
+   * @brief The length of the signature.
+   */
+  uint32_t len;
+  /**
+   * @brief The data signature.
+   */
+  uint8_t* data;
+} signature_t;
+
+/**
+ * @brief Creates a random 24 words mnemonic.
+ * @return Returns the generated mnemonic or NULL in case of error.
+ * The caller must take care of releasing the returned mnemonic with the
+ * cstring_free function.
+ * In case of error the error cause can be obtained using the error_message_utf8
+ * function.
+ */
+char* wallet_random_mnemonic();
+
+/**
+ * @brief Free a string.
+ * @param str: Pointer to the string to free.
+ */
+void cstring_free(char* str);
+
+/**
+ * @brief Generates a wallet from a mnemonic and the provided derivation path.
+ * @param mnemonic: The wallet mnemonic.
+ * @param dp: The derivation path used to derive the keys from the mnemonic.
+ * @return Returns a pointer to a valid wallet or NULL on error.
+ * The caller must take care of freeing the returned wallet instance with
+ * the wallet_free function.
+ * In case of error the error cause can be obtained using the error_message_utf8
+ * function.
+ */
+wallet_t* wallet_from_mnemonic(const char* mnemonic, const char* dp);
+
+/**
+ * @brief Free a wallet instance.
+ * @param wallet: The wallet to free.
+ */
+void wallet_free(wallet_t* wallet);
+
+/**
+ * @brief Gets the bec32 address associated to the wallet.
+ * @param wallet: Pointer to the wallet instance.
+ * @param hrp: The address human readable part.
+ * @return Returns the bech32 address associated to the wallet on success or
+ * NULL on error.
+ * The caller must take care of freeing the returned address with the
+ * cstring_free function.
+ * In case of error the error cause can be obtained using the error_message_utf8
+ * function.
+ */
+char* wallet_get_address(wallet_t *wallet, const char* hrp);
+
+/**
+ * @brief Performs the signature of the provided data.
+ * @param wallet: Pointer to the wallet instance.
+ * @param data: The data to be sign.
+ * @param len: The length of the data to sign.
+ * @return Returns a pointer to a signature_t instance on success, NULL on error.
+ * The caller must take care of freeing the returned signature with the
+ * wallet_sign_free function.
+ * In case of error the error cause can be obtained using the error_message_utf8
+ * function.
+ */
+signature_t* wallet_sign(wallet_t *wallet, const uint8_t* data, uint32_t len);
+
+/**
+ * @brief Free a signature instance.
+ * @param signature: Pointer to the signature to free.
+ */
+void wallet_sign_free(signature_t* signature);
+
+/**
+ * @brief Clears the last error.
+ */
+void clear_last_error();
+
+/**
+ * @brief Gets the last error message length.
+ */
+int last_error_length();
+
+/**
+ * @brief Gets the last error message as UTF-8 encoded string.
+ * @param out_buf: Pointer where will be stored the error message.
+ * @param buf_size: Size of out_buf.
+ * @return Returns the number of bytes wrote into out_buf or -1 there was an error.
+ */
+int error_message_utf8(char *out_buf, int buf_size);

--- a/packages/crw-wallet/ffi-binding.h
+++ b/packages/crw-wallet/ffi-binding.h
@@ -65,7 +65,7 @@ void wallet_free(wallet_t* wallet);
  * In case of error the error cause can be obtained using the error_message_utf8
  * function.
  */
-char* wallet_get_address(wallet_t *wallet, const char* hrp);
+char* wallet_get_bech32_address(wallet_t *wallet, const char* hrp);
 
 /**
  * @brief Performs the signature of the provided data.

--- a/packages/crw-wallet/ffi-binding.h
+++ b/packages/crw-wallet/ffi-binding.h
@@ -1,5 +1,5 @@
 /***
- * @brief This C header file expose the function defined inside the ffi crate.
+ * @brief This C header file expose the FFI defined inside the ffi crate.
  */
 
 #include <stdint.h>
@@ -37,16 +37,16 @@ char* wallet_random_mnemonic();
 void cstring_free(char* str);
 
 /**
- * @brief Generates a wallet from a mnemonic and the provided derivation path.
+ * @brief Derive a Secp256k1 key pair from the given mnemonic and derivation_path.
  * @param mnemonic: The wallet mnemonic.
- * @param dp: The derivation path used to derive the keys from the mnemonic.
+ * @param derivation_path: The derivation path used to derive the keys from the mnemonic.
  * @return Returns a pointer to a valid wallet or NULL on error.
  * The caller must take care of freeing the returned wallet instance with
  * the wallet_free function.
  * In case of error the error cause can be obtained using the error_message_utf8
  * function.
  */
-wallet_t* wallet_from_mnemonic(const char* mnemonic, const char* dp);
+wallet_t* wallet_from_mnemonic(const char* mnemonic, const char* derivation_path);
 
 /**
  * @brief Free a wallet instance.
@@ -70,7 +70,7 @@ char* wallet_get_address(wallet_t *wallet, const char* hrp);
 /**
  * @brief Performs the signature of the provided data.
  * @param wallet: Pointer to the wallet instance.
- * @param data: The data to be sign.
+ * @param data: The data to sign.
  * @param len: The length of the data to sign.
  * @return Returns a pointer to a signature_t instance on success, NULL on error.
  * The caller must take care of freeing the returned signature with the
@@ -100,6 +100,6 @@ int last_error_length();
  * @brief Gets the last error message as UTF-8 encoded string.
  * @param out_buf: Pointer where will be stored the error message.
  * @param buf_size: Size of out_buf.
- * @return Returns the number of bytes wrote into out_buf or -1 there was an error.
+ * @return Returns the number of bytes wrote into out_buf or -1 on error.
  */
 int error_message_utf8(char *out_buf, int buf_size);

--- a/packages/crw-wallet/ffi-binding.h
+++ b/packages/crw-wallet/ffi-binding.h
@@ -68,7 +68,7 @@ void wallet_free(wallet_t* wallet);
 char* wallet_get_bech32_address(wallet_t *wallet, const char* hrp);
 
 /**
- * @brief GGets secp256 public key from the wallet.
+ * @brief Gets secp256 public key from the wallet.
  * @param wallet: Pointer to the wallet instance.
  * @param out_buffer: Pointer where will be stored the public key
  * @param size: Size of out_buffer.

--- a/packages/crw-wallet/src/ffi.rs
+++ b/packages/crw-wallet/src/ffi.rs
@@ -152,13 +152,14 @@ pub extern "C" fn wallet_sign(
     null_pointer_check!(data);
 
     let signature = unsafe {
-        let data = std::slice::from_raw_parts(data, len as usize);
-        match ptr.as_ref().unwrap().sign(data).as_mut() {
+        let data = std::slice::from_raw_parts(data, data_len as usize);
+        match ptr.as_ref().unwrap().sign(data) {
             Ok(s) => {
-                let ptr = s.as_mut_ptr();
+                let mut sign = s.to_owned();
+                let ptr = sign.as_mut_ptr();
                 let vec_len = s.len() as c_uint;
                 // Prevent deallocation from rust, the array now can be reached only from the ptr variable.
-                mem::forget(s);
+                mem::forget(sign);
 
                 Signature {
                     len: vec_len,

--- a/packages/crw-wallet/src/ffi.rs
+++ b/packages/crw-wallet/src/ffi.rs
@@ -2,7 +2,6 @@
 use crate::crypto::MnemonicWallet;
 use crate::WalletError;
 use bip39::{Language, Mnemonic, MnemonicType};
-use ffi_helpers::error_handling::error_message_utf8;
 use libc::{c_char, c_uchar};
 use std::ffi::{CStr, CString};
 use std::mem;
@@ -31,7 +30,7 @@ pub extern "C" fn cstring_free(s: *mut c_char) {
 ///
 /// # Errors
 /// This function returns a nullptr in case of error and store the error cause in a local thread
-/// global variable that can be accessed using the [`error_message_utf8`] function.
+/// global variable that can be accessed using the [error_message_utf8](ffi_helpers::error_handling::error_message_utf8) function.
 #[no_mangle]
 pub extern "C" fn wallet_random_mnemonic() -> *mut c_char {
     let mnemonic = Mnemonic::new(MnemonicType::Words24, Language::English);
@@ -54,7 +53,7 @@ pub extern "C" fn wallet_random_mnemonic() -> *mut c_char {
 ///
 /// # Errors
 /// This function returns a nullptr in case of error and store the error cause in a local thread
-/// global variable that can be accessed using the [`error_message_utf8`] function.
+/// global variable that can be accessed using the [error_message_utf8](ffi_helpers::error_handling::error_message_utf8) function.
 #[no_mangle]
 pub extern "C" fn wallet_from_mnemonic(
     mnemonic: *const c_char,
@@ -99,7 +98,7 @@ pub extern "C" fn wallet_free(ptr: *mut MnemonicWallet) {
 ///
 /// # Errors
 /// This function returns a nullptr in case of error and store the error cause in a local thread
-/// global variable that can be accessed using the [`error_message_utf8`] function.
+/// global variable that can be accessed using the [error_message_utf8](ffi_helpers::error_handling::error_message_utf8) function.
 #[no_mangle]
 pub extern "C" fn wallet_get_bech32_address(
     ptr: *const MnemonicWallet,
@@ -141,7 +140,7 @@ pub extern "C" fn wallet_get_bech32_address(
 ///
 /// # Errors
 /// This function returns a nullptr in case of error and store the error cause in a local thread
-/// global variable that can be accessed using the [`error_message_utf8`] function.
+/// global variable that can be accessed using the [error_message_utf8](ffi_helpers::error_handling::error_message_utf8) function.
 #[no_mangle]
 pub extern "C" fn wallet_sign(
     ptr: *const MnemonicWallet,

--- a/packages/crw-wallet/src/ffi.rs
+++ b/packages/crw-wallet/src/ffi.rs
@@ -2,11 +2,11 @@
 use crate::crypto::MnemonicWallet;
 use crate::WalletError;
 use bip39::{Language, Mnemonic, MnemonicType};
-use libc::{c_char, c_uchar};
+use libc::{c_char, c_int, c_uchar, size_t};
 use std::ffi::{CStr, CString};
-use std::mem;
 use std::os::raw::c_uint;
 use std::ptr::null_mut;
+use std::{mem, slice};
 
 #[repr(C)]
 pub struct Signature {
@@ -26,7 +26,7 @@ pub extern "C" fn cstring_free(s: *mut c_char) {
 }
 
 /// Generates a random mnemonic of 24 words.
-/// The returned mnemonic must bee freed using the [`cstring_free`] function to avoid memory leaks.
+/// The returned mnemonic must be freed using the [`cstring_free`] function to avoid memory leaks.
 ///
 /// # Errors
 /// This function returns a nullptr in case of error and store the error cause in a local thread
@@ -48,7 +48,7 @@ pub extern "C" fn wallet_random_mnemonic() -> *mut c_char {
 }
 
 /// Derive a Secp256k1 key pair from the given mnemonic_phrase and derivation_path.
-/// The returned [`MnemonicWallet`] ptr must bee freed using the [`wallet_free`] function to avoid memory
+/// The returned [`MnemonicWallet`] ptr must be freed using the [`wallet_free`] function to avoid memory
 /// leaks.
 ///
 /// # Errors

--- a/packages/crw-wallet/src/ffi.rs
+++ b/packages/crw-wallet/src/ffi.rs
@@ -1,0 +1,199 @@
+//! Provides the FFI to interact with [`MnemonicWallet`] from other programming languages.
+use crate::crypto::MnemonicWallet;
+use crate::WalletError;
+use bip39::{Language, Mnemonic, MnemonicType};
+use ffi_helpers::error_handling::error_message_utf8;
+use libc::{c_char, c_uchar};
+use std::ffi::{CStr, CString};
+use std::mem;
+use std::os::raw::c_uint;
+use std::ptr::null_mut;
+
+#[repr(C)]
+pub struct Signature {
+    len: c_uint,
+    data: *mut c_uchar,
+}
+
+/// Release a string returned from rust.
+#[no_mangle]
+pub extern "C" fn cstring_free(s: *mut c_char) {
+    unsafe {
+        if s.is_null() {
+            return;
+        }
+        CString::from_raw(s)
+    };
+}
+
+/// Generates a random mnemonic of 24 words.
+/// The returned mnemonic must bee freed using the [`cstring_free`] function to avoid memory leaks.
+///
+/// # Errors
+/// This function returns a nullptr in case of error and store the error cause in a local thread
+/// global variable that can be accessed using the [`error_message_utf8`] function.
+#[no_mangle]
+pub extern "C" fn wallet_random_mnemonic() -> *mut c_char {
+    let mnemonic = Mnemonic::new(MnemonicType::Words24, Language::English);
+    let phrase = mnemonic.phrase().to_owned();
+
+    let phrase_c_str = match CString::new(phrase) {
+        Ok(s) => s,
+        Err(e) => {
+            ffi_helpers::update_last_error(e);
+            return null_mut();
+        }
+    };
+
+    phrase_c_str.into_raw()
+}
+
+/// Derive a Secp256k1 key pair from the given mnemonic_phrase and derivation_path.
+/// The returned [`MnemonicWallet`] ptr must bee freed using the [`wallet_free`] function to avoid memory
+/// leaks.
+///
+/// # Errors
+/// This function returns a nullptr in case of error and store the error cause in a local thread
+/// global variable that can be accessed using the [`error_message_utf8`] function.
+#[no_mangle]
+pub extern "C" fn wallet_from_mnemonic(
+    mnemonic: *const c_char,
+    derivation_path: *const c_char,
+) -> *mut MnemonicWallet {
+    if mnemonic.is_null() {
+        ffi_helpers::update_last_error(WalletError::Mnemonic("null mnemonic ptr".to_owned()));
+        return null_mut();
+    }
+    if derivation_path.is_null() {
+        ffi_helpers::update_last_error(WalletError::DerivationPath(
+            "null derivation path ptr".to_owned(),
+        ));
+        return null_mut();
+    }
+
+    let mnemonic_c_str = unsafe { CStr::from_ptr(mnemonic).to_string_lossy() };
+    let dp_c_str = unsafe { CStr::from_ptr(derivation_path).to_string_lossy() };
+
+    let wallet = match MnemonicWallet::new(mnemonic_c_str.as_ref(), dp_c_str.as_ref()) {
+        Ok(w) => w,
+        Err(e) => {
+            ffi_helpers::update_last_error(e);
+            return null_mut();
+        }
+    };
+
+    Box::into_raw(Box::new(wallet))
+}
+
+/// Deallocate a [`MnemonicWallet`] instance.
+#[no_mangle]
+pub extern "C" fn wallet_free(ptr: *mut MnemonicWallet) {
+    if ptr.is_null() {
+        return;
+    }
+
+    Box::from(ptr);
+}
+
+/// Gets the bech32 address derived from the mnemonic and the provided human readable part.
+///
+/// # Errors
+/// This function returns a nullptr in case of error and store the error cause in a local thread
+/// global variable that can be accessed using the [`error_message_utf8`] function.
+#[no_mangle]
+pub extern "C" fn wallet_get_bech32_address(
+    ptr: *const MnemonicWallet,
+    hrp: *const c_char,
+) -> *mut c_char {
+    null_pointer_check!(ptr);
+
+    if hrp.is_null() {
+        ffi_helpers::update_last_error(WalletError::Hrp("received null hrp".to_owned()));
+        return null_mut();
+    }
+
+    let hrp_cstr = unsafe { CStr::from_ptr(hrp).to_string_lossy() };
+
+    let address = unsafe {
+        match ptr.as_ref().unwrap().get_bech32_address(hrp_cstr.as_ref()) {
+            Ok(a) => a,
+            Err(e) => {
+                ffi_helpers::update_last_error(e);
+                return null_mut();
+            }
+        }
+    };
+
+    let address_c_str = match CString::new(address) {
+        Ok(s) => s,
+        Err(e) => {
+            ffi_helpers::update_last_error(e);
+            return null_mut();
+        }
+    };
+
+    address_c_str.into_raw()
+}
+
+/// Generates a signature of the provided data.
+/// The returned [`Signature`] pointer must bee freed using the [`wallet_sign_free`] function
+/// to avoid memory leaks.
+///
+/// # Errors
+/// This function returns a nullptr in case of error and store the error cause in a local thread
+/// global variable that can be accessed using the [`error_message_utf8`] function.
+#[no_mangle]
+pub extern "C" fn wallet_sign(
+    ptr: *const MnemonicWallet,
+    data: *const c_uchar,
+    data_len: c_uint,
+) -> *mut Signature {
+    null_pointer_check!(ptr);
+    null_pointer_check!(data);
+
+    let signature = unsafe {
+        let data = std::slice::from_raw_parts(data, len as usize);
+        match ptr.as_ref().unwrap().sign(data).as_mut() {
+            Ok(s) => {
+                let ptr = s.as_mut_ptr();
+                let vec_len = s.len() as c_uint;
+                // Prevent deallocation from rust, the array now can be reached only from the ptr variable.
+                mem::forget(s);
+
+                Signature {
+                    len: vec_len,
+                    data: ptr,
+                }
+            }
+            Err(e) => {
+                ffi_helpers::update_last_error(e.to_owned());
+                return null_mut();
+            }
+        }
+    };
+
+    Box::into_raw(Box::from(signature))
+}
+
+/// Deallocate a [`Signature`] instance.
+#[no_mangle]
+pub extern "C" fn wallet_sign_free(ptr: *mut Signature) {
+    if ptr.is_null() {
+        return;
+    }
+
+    unsafe {
+        let signature = ptr.as_ref().unwrap();
+
+        drop(Vec::from_raw_parts(
+            signature.data,
+            signature.len as usize,
+            signature.len as usize,
+        ));
+    };
+
+    Box::from(ptr);
+}
+
+// Macro to export the ffi_helpers's functions used to access the error message from other programming languages.
+export_error_handling_functions!();

--- a/packages/crw-wallet/src/lib.rs
+++ b/packages/crw-wallet/src/lib.rs
@@ -1,7 +1,13 @@
+#[cfg(feature = "ffi")]
+#[macro_use]
+extern crate ffi_helpers;
+
 pub mod crypto;
 mod error;
+pub use crate::error::WalletError;
 
 #[cfg(feature = "wasm-bindgen")]
 pub mod wasm32_bindgen;
 
-pub use crate::error::WalletError;
+#[cfg(feature = "ffi")]
+pub mod ffi;


### PR DESCRIPTION
This PR introduces the  **FFI** (Foreign Function Interface) to expose the `crw-wallet` package functionalities to other programming languages.